### PR TITLE
Distribute as ES5 to simplify bundling

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,4 @@
 {
-  "optional": [
-    "es7.decorators"
-  ]
+    "presets": ["env"],
+    "plugins": ["transform-decorators-legacy"]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
-- iojs
+  - '4'
+  - '6'
+  - '8'

--- a/README.md
+++ b/README.md
@@ -9,17 +9,18 @@ $ npm install alias-decorator
 
 ## Usage
 ```js
-import {alias} from 'alias-decorator'
+import alias from 'alias-decorator'
 
 class Dog {
-  @alias('bark')
+  @alias('bark', 'growl')
   speak () {
     console.log('woof')
   }
 }
 
 const dog = new Dog()
-dog.speak === dog.bark
+dog.speak === dog.bark // true
+dog.bark === dog.growl // true
 ```
 
-`alias` copies your property descriptor directly, so properties like `enumerable` will match.
+`alias` copies your property descriptor directly, so properties like `enumerable` are preserved.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Alias methods via an ES7 decorator",
   "main": "./src",
   "scripts": {
-    "test": "standard && babel-tape-runner test/*.js"
+    "test": "standard --parser babel-eslint && babel-tape-runner test/*.js"
   },
   "repository": {
     "type": "git",
@@ -23,9 +23,12 @@
   },
   "homepage": "https://github.com/bendrucker/alias-decorator",
   "devDependencies": {
-    "babel": "~5.1.10",
-    "babel-tape-runner": "~1.1.0",
-    "standard": "bendrucker/standard#babel",
-    "tape": "~4.0.0"
-  }
+    "babel-eslint": "^8.0.3",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-preset-env": "^1.6.1",
+    "babel-tape-runner": "^2.0.1",
+    "standard": "^10.0.3",
+    "tape": "^4.8.0"
+  },
+  "dependencies": {}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,11 @@
 'use strict'
 
-export function alias (...aliases) {
+var toArray = [].slice
+
+module.exports = function alias () {
+  var aliases = toArray.call(arguments)
   return function (target, name, descriptor) {
-    aliases.forEach(alias => {
+    aliases.forEach(function (alias) {
       Object.defineProperty(target, alias, descriptor)
     })
   }

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 import test from 'tape'
-import {alias} from '../'
+import alias from '../'
 
 test('alias', (t) => {
   const obj = {


### PR DESCRIPTION
Same rationale as/similar changes to [this](https://github.com/bendrucker/angular-annotation-decorator/pull/3).

- [BREAKING CHANGE] uses a default export so users can easily choose a different name
- runs tests on LTS versions of Node
- update test dependencies